### PR TITLE
Fix backend startup path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 2025-05-19 Setup FastAPI backend with React/Vite/Tailwind frontend skeleton
 2025-05-19 Add README instructions for virtual environment and local startup
 2025-05-20 Implement file-based project repo and project listing UI
+2025-05-20 Fix dev.sh backend start path and update README

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ npm run dev
 ```
 
 ### Backend
+Run the FastAPI backend from the repository root so package imports work correctly:
 ```bash
-cd backend/app
-uvicorn main:app --reload
+uvicorn backend.app.main:app --reload
 ```
 
 Open <http://localhost:5173> during development. When the frontend is built, the

--- a/dev.sh
+++ b/dev.sh
@@ -17,10 +17,8 @@ pip install -r requirements.txt
 
 # Step 4: Start backend in background
 echo "Starting FastAPI backend..."
-cd backend/app
-uvicorn main:app --reload &
+uvicorn backend.app.main:app --reload &
 BACKEND_PID=$!
-cd ../../
 
 # Step 5: Start frontend in background
 echo "Starting frontend dev server..."


### PR DESCRIPTION
## Summary
- run FastAPI with module path in `dev.sh`
- document updated backend start command in README
- note change in CHANGELOG

## Testing
- `pytest -q`