### PR TITLE
Add scrolling project carousel and extra sample project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 2025-05-19 Add README instructions for virtual environment and local startup
 2025-05-20 Implement file-based project repo and project listing UI
 2025-05-20 Fix dev.sh backend start path and update README
+2025-05-20 Add project carousel and second sample project

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,6 +19,9 @@ app.add_middleware(
 
 repo = FileProjectRepository(Path(__file__).resolve().parents[1] / "project_store")
 
+images_path = Path(__file__).resolve().parents[1] / "project_store" / "images"
+app.mount("/images", StaticFiles(directory=images_path), name="images")
+
 templates = Jinja2Templates(directory=str(Path(__file__).resolve().parent / "templates"))
 
 

--- a/backend/project_store/another_project.json
+++ b/backend/project_store/another_project.json
@@ -1,0 +1,8 @@
+{
+  "id": "another-project",
+  "title": "Another Project",
+  "image": "images/2.png",
+  "repo_url": "https://github.com/example/another-project",
+  "description": "This is another sample project to showcase multiple entries.",
+  "demo_url": "https://example.com/demo2"
+}

--- a/backend/project_store/sample_project.json
+++ b/backend/project_store/sample_project.json
@@ -1,7 +1,7 @@
 {
   "id": "sample-project",
   "title": "Sample Project",
-  "image": "images/sample.png",
+  "image": "images/1.png",
   "repo_url": "https://github.com/example/sample-project",
   "description": "This is a sample project used to demonstrate the portfolio layout.",
   "demo_url": "https://example.com/demo"

--- a/frontend/src/components/ProjectCarousel.tsx
+++ b/frontend/src/components/ProjectCarousel.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef, useState } from 'react'
+
+export interface Project {
+  id: string
+  title: string
+  image?: string
+  repo_url: string
+  description: string
+  demo_url: string
+}
+
+const baseUrl = import.meta.env.DEV ? 'http://localhost:8000' : ''
+
+export default function ProjectCarousel() {
+  const [projects, setProjects] = useState<Project[]>([])
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    fetch(`${baseUrl}/api/projects`)
+      .then((res) => res.json())
+      .then((data) => setProjects(data))
+      .catch(() => setProjects([]))
+  }, [])
+
+  const scroll = (offset: number) => {
+    containerRef.current?.scrollBy({ left: offset, behavior: 'smooth' })
+  }
+
+  return (
+    <div className="relative">
+      <button
+        className="absolute left-0 top-1/2 -translate-y-1/2 bg-white bg-opacity-70 rounded-full p-2 shadow"
+        onClick={() => scroll(-300)}
+      >
+        &#8249;
+      </button>
+      <div
+        ref={containerRef}
+        className="overflow-x-auto flex space-x-4 py-4 px-8 scroll-smooth"
+      >
+        {projects.map((p) => {
+          const img = p.image ? `${baseUrl}/${p.image}` : undefined
+          return (
+            <div
+              key={p.id}
+              onClick={() => (window.location.href = `/project/${p.id}`)}
+              className="relative w-64 h-40 flex-shrink-0 rounded shadow cursor-pointer bg-gray-200 bg-cover bg-center"
+              style={img ? { backgroundImage: `url(${img})` } : {}}
+            >
+              <div className="absolute inset-0 bg-black bg-opacity-40 rounded flex items-end p-2">
+                <h3 className="text-white text-lg font-semibold">{p.title}</h3>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+      <button
+        className="absolute right-0 top-1/2 -translate-y-1/2 bg-white bg-opacity-70 rounded-full p-2 shadow"
+        onClick={() => scroll(300)}
+      >
+        &#8250;
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,10 +1,10 @@
-import ProjectList from '../components/ProjectList'
+import ProjectCarousel from '../components/ProjectCarousel'
 
 export default function LandingPage() {
   return (
     <section className="p-4">
       <h1 className="text-3xl font-bold mb-4">My Portfolio</h1>
-      <ProjectList />
+      <ProjectCarousel />
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- add route to serve project images
- add second sample project entry and fix image path in the first
- implement `ProjectCarousel` component for horizontally scrolling projects
- show carousel on the landing page

## Testing
- `pytest -q`