### PR TITLE
Add debug logging toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 2025-05-20 Implement file-based project repo and project listing UI
 2025-05-20 Fix dev.sh backend start path and update README
 2025-05-20 Add project carousel and second sample project
+2025-05-20 Add debug logging and toggle for frontend and backend

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ npm run build
 ./dev.sh
 ```
 
+### Debug Logging
+Set the `DEBUG` environment variable to `1` for verbose backend logs and
+`VITE_ENABLE_DEBUG=true` for frontend console logs. Example:
+
+```bash
+DEBUG=1 VITE_ENABLE_DEBUG=true ./dev.sh
+```
+
 ### Adding Projects
 Project definition files live in `backend/project_store`. Optional images can be
 placed in `backend/project_store/images` and referenced from the `image` field.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,9 +4,17 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+import logging
+import os
 
 from .models import Project
 from .repositories.project_repository import FileProjectRepository
+
+logging.basicConfig(
+    level=logging.DEBUG if os.getenv("DEBUG") == "1" else logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+logger = logging.getLogger(__name__)
 
 app = FastAPI()
 
@@ -27,19 +35,25 @@ templates = Jinja2Templates(directory=str(Path(__file__).resolve().parent / "tem
 
 @app.get("/api/projects", response_model=list[Project])
 def list_projects():
-    return repo.list_projects()
+    logger.debug("Listing all projects")
+    projects = repo.list_projects()
+    logger.debug("Returning %d projects", len(projects))
+    return projects
 
 
 @app.get("/api/projects/{project_id}", response_model=Project)
 def get_project(project_id: str):
+    logger.debug("Fetching project %s", project_id)
     project = repo.get_project(project_id)
     if not project:
         raise HTTPException(status_code=404, detail="Project not found")
+    logger.debug("Found project %s", project_id)
     return project
 
 
 @app.get("/project/{project_id}", response_class=HTMLResponse)
 def project_page(request: Request, project_id: str):
+    logger.debug("Rendering page for project %s", project_id)
     project = repo.get_project(project_id)
     if not project:
         raise HTTPException(status_code=404, detail="Project not found")

--- a/backend/app/repositories/project_repository.py
+++ b/backend/app/repositories/project_repository.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import List, Protocol, Optional
 
 from ..models import Project
+
+logger = logging.getLogger(__name__)
 
 
 class ProjectRepository(Protocol):
@@ -23,8 +26,10 @@ class FileProjectRepository:
         return self.directory / f"{project_id}.json"
 
     def list_projects(self) -> List[Project]:
+        logger.debug("Reading projects from %s", self.directory)
         projects = []
         for file in self.directory.glob("*.json"):
+            logger.debug("Loading project file %s", file)
             with file.open("r") as f:
                 data = json.load(f)
                 projects.append(Project(**data))
@@ -34,6 +39,7 @@ class FileProjectRepository:
         path = self._project_path(project_id)
         if not path.exists():
             return None
+        logger.debug("Loading project %s from %s", project_id, path)
         with path.open("r") as f:
             data = json.load(f)
             return Project(**data)

--- a/dev.sh
+++ b/dev.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Export optional debug environment variables if provided
+: "${DEBUG:=}"
+: "${VITE_ENABLE_DEBUG:=}"
+export DEBUG VITE_ENABLE_DEBUG
+
 # Function to kill existing processes
 kill_existing_processes() {
   echo "Checking for existing backend and frontend processes..."

--- a/frontend/src/components/ProjectCarousel.tsx
+++ b/frontend/src/components/ProjectCarousel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { debugLog } from '../utils/logger'
 
 export interface Project {
   id: string
@@ -16,10 +17,20 @@ export default function ProjectCarousel() {
   const containerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
+    debugLog('Fetching projects from', `${baseUrl}/api/projects`)
     fetch(`${baseUrl}/api/projects`)
-      .then((res) => res.json())
-      .then((data) => setProjects(data))
-      .catch(() => setProjects([]))
+      .then((res) => {
+        debugLog('Received response', res.status)
+        return res.json()
+      })
+      .then((data) => {
+        debugLog('Project data', data)
+        setProjects(data)
+      })
+      .catch((err) => {
+        debugLog('Failed to load projects', err)
+        setProjects([])
+      })
   }, [])
 
   const scroll = (offset: number) => {

--- a/frontend/src/components/ProjectList.tsx
+++ b/frontend/src/components/ProjectList.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { debugLog } from '../utils/logger'
 
 export interface Project {
   id: string
@@ -15,10 +16,20 @@ export default function ProjectList() {
   const [projects, setProjects] = useState<Project[]>([])
 
   useEffect(() => {
+    debugLog('Fetching projects from', `${baseUrl}/api/projects`)
     fetch(`${baseUrl}/api/projects`)
-      .then((res) => res.json())
-      .then((data) => setProjects(data))
-      .catch(() => setProjects([]))
+      .then((res) => {
+        debugLog('Received response', res.status)
+        return res.json()
+      })
+      .then((data) => {
+        debugLog('Project data', data)
+        setProjects(data)
+      })
+      .catch((err) => {
+        debugLog('Failed to load projects', err)
+        setProjects([])
+      })
   }, [])
 
   return (

--- a/frontend/src/utils/logger.ts
+++ b/frontend/src/utils/logger.ts
@@ -1,0 +1,7 @@
+export const debugEnabled = import.meta.env.VITE_ENABLE_DEBUG === 'true'
+
+export function debugLog(...args: unknown[]) {
+  if (debugEnabled) {
+    console.log('[DEBUG]', ...args)
+  }
+}


### PR DESCRIPTION
## Summary
- implement debug logging in backend with optional `DEBUG=1` env var
- add frontend logger util and log project fetches
- expose DEBUG and VITE_ENABLE_DEBUG through dev.sh
- document debug logging in README

## Testing
- `pytest -q`