### PR TITLE
Fix project detail links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,5 @@
 2025-05-20 Add project carousel and second sample project
 2025-05-20 Add debug logging and toggle for frontend and backend
 2025-05-20 Fix backend startup when jinja2 missing; add optional template fallback
+2025-05-20 Fix project links to open backend project pages in dev mode
+2025-05-20 Document backend project page URLs in README

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ uvicorn backend.app.main:app --reload
 
 Open <http://localhost:5173> during development. When the frontend is built, the
 FastAPI backend serves the compiled files on <http://localhost:8000>.
+During development the backend also renders individual project pages on
+<http://localhost:8000>, and the frontend links to these pages automatically.
 
 ### Build Frontend
 ```bash

--- a/frontend/src/components/ProjectCarousel.tsx
+++ b/frontend/src/components/ProjectCarousel.tsx
@@ -54,7 +54,7 @@ export default function ProjectCarousel() {
           return (
             <div
               key={p.id}
-              onClick={() => (window.location.href = `/project/${p.id}`)}
+              onClick={() => (window.location.href = `${baseUrl}/project/${p.id}`)}
               className="relative w-64 h-40 flex-shrink-0 rounded shadow cursor-pointer bg-gray-200 bg-cover bg-center"
               style={img ? { backgroundImage: `url(${img})` } : {}}
             >

--- a/frontend/src/components/ProjectList.tsx
+++ b/frontend/src/components/ProjectList.tsx
@@ -38,7 +38,7 @@ export default function ProjectList() {
         <div key={p.id} className="inline-block w-64 bg-white shadow rounded p-4">
           <h3 className="text-lg font-semibold mb-2">{p.title}</h3>
           <p className="text-sm mb-2">{p.description.slice(0, 80)}...</p>
-          <a className="text-blue-500" href={`/project/${p.id}`}>View Project</a>
+          <a className="text-blue-500" href={`${baseUrl}/project/${p.id}`}>View Project</a>
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- fix project links so dev server opens pages from FastAPI backend
- mention backend project page URLs in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`