### PR TITLE
Serve project details from frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 2025-05-20 Fix backend startup when jinja2 missing; add optional template fallback
 2025-05-20 Fix project links to open backend project pages in dev mode
 2025-05-20 Document backend project page URLs in README
+2025-05-21 Render project details within frontend at /project/<id>

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ uvicorn backend.app.main:app --reload
 
 Open <http://localhost:5173> during development. When the frontend is built, the
 FastAPI backend serves the compiled files on <http://localhost:8000>.
-During development the backend also renders individual project pages on
-<http://localhost:8000>, and the frontend links to these pages automatically.
+Project detail pages are now rendered by the frontend at `/project/<id>` and
+fetch their data from the backend API.
 
 ### Build Frontend
 ```bash

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,24 @@
+import { useEffect, useState } from 'react'
 import LandingPage from './pages/LandingPage'
 import MainLayout from './layouts/MainLayout'
+import ProjectDetailPage from './pages/ProjectDetailPage'
 
 export default function App() {
-  return (
-    <MainLayout>
-      <LandingPage />
-    </MainLayout>
-  )
+  const [path, setPath] = useState(window.location.pathname)
+
+  useEffect(() => {
+    const onPop = () => setPath(window.location.pathname)
+    window.addEventListener('popstate', onPop)
+    return () => window.removeEventListener('popstate', onPop)
+  }, [])
+
+  let content
+  if (path.startsWith('/project/')) {
+    const projectId = path.replace('/project/', '')
+    content = <ProjectDetailPage projectId={projectId} />
+  } else {
+    content = <LandingPage />
+  }
+
+  return <MainLayout>{content}</MainLayout>
 }

--- a/frontend/src/components/ProjectCarousel.tsx
+++ b/frontend/src/components/ProjectCarousel.tsx
@@ -54,7 +54,7 @@ export default function ProjectCarousel() {
           return (
             <div
               key={p.id}
-              onClick={() => (window.location.href = `${baseUrl}/project/${p.id}`)}
+              onClick={() => (window.location.href = `/project/${p.id}`)}
               className="relative w-64 h-40 flex-shrink-0 rounded shadow cursor-pointer bg-gray-200 bg-cover bg-center"
               style={img ? { backgroundImage: `url(${img})` } : {}}
             >

--- a/frontend/src/components/ProjectList.tsx
+++ b/frontend/src/components/ProjectList.tsx
@@ -38,7 +38,7 @@ export default function ProjectList() {
         <div key={p.id} className="inline-block w-64 bg-white shadow rounded p-4">
           <h3 className="text-lg font-semibold mb-2">{p.title}</h3>
           <p className="text-sm mb-2">{p.description.slice(0, 80)}...</p>
-          <a className="text-blue-500" href={`${baseUrl}/project/${p.id}`}>View Project</a>
+          <a className="text-blue-500" href={`/project/${p.id}`}>View Project</a>
         </div>
       ))}
     </div>

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react'
+import { debugLog } from '../utils/logger'
+
+export interface Project {
+  id: string
+  title: string
+  image?: string
+  repo_url: string
+  description: string
+  demo_url: string
+}
+
+const baseUrl = import.meta.env.DEV ? 'http://localhost:8000' : ''
+
+export default function ProjectDetailPage({ projectId }: { projectId: string }) {
+  const [project, setProject] = useState<Project | null>(null)
+
+  useEffect(() => {
+    debugLog('Fetching project', projectId)
+    fetch(`${baseUrl}/api/projects/${projectId}`)
+      .then((res) => res.json())
+      .then((data) => setProject(data))
+      .catch((err) => debugLog('Failed to load project', err))
+  }, [projectId])
+
+  if (!project) {
+    return <p>Loading...</p>
+  }
+
+  return (
+    <div className="p-4 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">{project.title}</h1>
+      <p className="mb-4">{project.description}</p>
+      <p className="mb-2">
+        <a className="text-blue-500" href={project.repo_url}>
+          GitHub Repo
+        </a>
+      </p>
+      <p>
+        <a className="text-blue-500" href={project.demo_url}>
+          Live Demo
+        </a>
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- implement a simple router in `App.tsx`
- add `ProjectDetailPage` to fetch project data
- update carousel and list links to use `/project/<id>` on the frontend
- document new project detail route in README

## Testing
- `bash -lc 'npm --version'` *(fails: command not found)*
