### PR TITLE
Improve project detail view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,5 @@
 2025-05-20 Document backend project page URLs in README
 2025-05-21 Render project details within frontend at /project/<id>
 2025-05-20 Remove backend HTML fallback and Jinja2 template
+2025-05-22 Improve project detail page with banner and external links
+  npm install failed: vite not found

--- a/frontend/src/components/ProjectCarousel.tsx
+++ b/frontend/src/components/ProjectCarousel.tsx
@@ -1,24 +1,15 @@
 import { useEffect, useRef, useState } from 'react'
 import { debugLog } from '../utils/logger'
-
-export interface Project {
-  id: string
-  title: string
-  image?: string
-  repo_url: string
-  description: string
-  demo_url: string
-}
-
-const baseUrl = import.meta.env.DEV ? 'http://localhost:8000' : ''
+import { Project } from '../types'
+import { API_BASE_URL } from '../utils/api'
 
 export default function ProjectCarousel() {
   const [projects, setProjects] = useState<Project[]>([])
   const containerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    debugLog('Fetching projects from', `${baseUrl}/api/projects`)
-    fetch(`${baseUrl}/api/projects`)
+    debugLog('Fetching projects from', `${API_BASE_URL}/api/projects`)
+    fetch(`${API_BASE_URL}/api/projects`)
       .then((res) => {
         debugLog('Received response', res.status)
         return res.json()
@@ -50,7 +41,7 @@ export default function ProjectCarousel() {
         className="overflow-x-auto flex space-x-4 py-4 px-8 scroll-smooth"
       >
         {projects.map((p) => {
-          const img = p.image ? `${baseUrl}/${p.image}` : undefined
+          const img = p.image ? `${API_BASE_URL}/${p.image}` : undefined
           return (
             <div
               key={p.id}

--- a/frontend/src/components/ProjectDetail.tsx
+++ b/frontend/src/components/ProjectDetail.tsx
@@ -1,0 +1,39 @@
+import { Project } from '../types'
+import { API_BASE_URL } from '../utils/api'
+
+export default function ProjectDetail({ project }: { project: Project }) {
+  const imageUrl = project.image ? `${API_BASE_URL}/${project.image}` : undefined
+
+  return (
+    <article className="bg-white shadow rounded overflow-hidden">
+      {imageUrl && (
+        <div
+          className="h-48 md:h-64 bg-cover bg-center"
+          style={{ backgroundImage: `url(${imageUrl})` }}
+        />
+      )}
+      <div className="p-4">
+        <h1 className="text-3xl font-bold mb-4">{project.title}</h1>
+        <p className="mb-4">{project.description}</p>
+        <div className="space-x-4">
+          <a
+            className="text-blue-600 underline"
+            href={project.demo_url}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Live Demo
+          </a>
+          <a
+            className="text-blue-600 underline"
+            href={project.repo_url}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            GitHub Repo
+          </a>
+        </div>
+      </div>
+    </article>
+  )
+}

--- a/frontend/src/components/ProjectList.tsx
+++ b/frontend/src/components/ProjectList.tsx
@@ -1,23 +1,14 @@
 import { useEffect, useState } from 'react'
 import { debugLog } from '../utils/logger'
-
-export interface Project {
-  id: string
-  title: string
-  image?: string
-  repo_url: string
-  description: string
-  demo_url: string
-}
-
-const baseUrl = import.meta.env.DEV ? 'http://localhost:8000' : ''
+import { Project } from '../types'
+import { API_BASE_URL } from '../utils/api'
 
 export default function ProjectList() {
   const [projects, setProjects] = useState<Project[]>([])
 
   useEffect(() => {
-    debugLog('Fetching projects from', `${baseUrl}/api/projects`)
-    fetch(`${baseUrl}/api/projects`)
+    debugLog('Fetching projects from', `${API_BASE_URL}/api/projects`)
+    fetch(`${API_BASE_URL}/api/projects`)
       .then((res) => {
         debugLog('Received response', res.status)
         return res.json()

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -1,23 +1,15 @@
 import { useEffect, useState } from 'react'
 import { debugLog } from '../utils/logger'
-
-export interface Project {
-  id: string
-  title: string
-  image?: string
-  repo_url: string
-  description: string
-  demo_url: string
-}
-
-const baseUrl = import.meta.env.DEV ? 'http://localhost:8000' : ''
+import { Project } from '../types'
+import { API_BASE_URL } from '../utils/api'
+import ProjectDetail from '../components/ProjectDetail'
 
 export default function ProjectDetailPage({ projectId }: { projectId: string }) {
   const [project, setProject] = useState<Project | null>(null)
 
   useEffect(() => {
     debugLog('Fetching project', projectId)
-    fetch(`${baseUrl}/api/projects/${projectId}`)
+    fetch(`${API_BASE_URL}/api/projects/${projectId}`)
       .then((res) => res.json())
       .then((data) => setProject(data))
       .catch((err) => debugLog('Failed to load project', err))
@@ -28,19 +20,8 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
   }
 
   return (
-    <div className="p-4 max-w-xl mx-auto">
-      <h1 className="text-2xl font-bold mb-4">{project.title}</h1>
-      <p className="mb-4">{project.description}</p>
-      <p className="mb-2">
-        <a className="text-blue-500" href={project.repo_url}>
-          GitHub Repo
-        </a>
-      </p>
-      <p>
-        <a className="text-blue-500" href={project.demo_url}>
-          Live Demo
-        </a>
-      </p>
+    <div className="p-4 max-w-3xl mx-auto">
+      <ProjectDetail project={project} />
     </div>
   )
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,8 @@
+export interface Project {
+  id: string
+  title: string
+  image?: string
+  repo_url: string
+  description: string
+  demo_url: string
+}

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,0 +1,1 @@
+export const API_BASE_URL = import.meta.env.DEV ? 'http://localhost:8000' : ''


### PR DESCRIPTION
## Summary
- share `Project` interface and base API URL
- add new `ProjectDetail` component to display banner, title, description and links
- refactor project list, carousel and detail page to use shared types and API URL
- show project details using new component with banner styling

## Testing
- `npm install` *(fails: vite not found)*