### PR TITLE
Improve Markdown rendering with react-markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@
 2025-05-23 Add in-browser repo viewer using isomorphic-git
 2025-05-24 Improve RepoBrowser rendering for markdown, json and code
 2025-05-24 Add Markdown styling and fix code spacing in RepoBrowser
+2025-05-24 Switch RepoBrowser to react-markdown with unified code highlighting

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ templates for project pages.
 
 Project detail pages include an in-browser GitHub repository viewer. The viewer
 clones the specified repository using `isomorphic-git` and displays a file tree
-and README preview directly in the browser.
+and README preview directly in the browser. Markdown and code blocks are
+rendered with `react-markdown` and Highlight.js for consistent styling.
 
 ### Build Frontend
 ```bash

--- a/dev.sh
+++ b/dev.sh
@@ -57,7 +57,6 @@ fi
 
 # Run npm commands in the frontend directory
 npm install
-npm install buffer @esbuild-plugins/node-globals-polyfill
 npm run dev &
 FRONTEND_PID=$!
 cd ..

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,15 +13,18 @@
     "buffer": "^6.0.3",
     "highlight.js": "^11.8.0",
     "isomorphic-git": "^1.21.0",
-    "marked": "^7.0.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-markdown": "^9.0.0",
+    "remark-gfm": "^3.0.1",
+    "rehype-highlight": "^6.0.0"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.9",
     "@types/react": "^18.2.14",
     "@types/react-dom": "^18.2.6",
     "@vitejs/plugin-react": "^3.0.0",
+    "vite-plugin-node-polyfills": "^0.16.0",
     "autoprefixer": "^10.4.13",
     "postcss": "^8.4.23",
     "tailwindcss": "^3.3.2",

--- a/frontend/src/components/MarkdownRenderer.tsx
+++ b/frontend/src/components/MarkdownRenderer.tsx
@@ -1,0 +1,26 @@
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeHighlight from 'rehype-highlight';
+import 'highlight.js/styles/github-dark.css';
+
+type Props = { markdown: string };
+
+export default function MarkdownRenderer({ markdown }: Props) {
+  return (
+    <article className="prose prose-slate dark:prose-invert max-w-none">
+      <ReactMarkdown
+        children={markdown}
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeHighlight]}
+        components={{
+          a: ({ node, ...props }) => (
+            <a {...props} className="text-blue-600 underline hover:text-blue-800" />
+          ),
+          img: ({ node, ...props }) => (
+            <img {...props} className="rounded-lg shadow mx-auto" loading="lazy" />
+          ),
+        }}
+      />
+    </article>
+  );
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,11 +1,15 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { nodePolyfills } from 'vite-plugin-node-polyfills';
 import { NodeGlobalsPolyfillPlugin } from '@esbuild-plugins/node-globals-polyfill';
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    nodePolyfills({ globals: { process: true, buffer: true } }),
+  ],
   build: {
-    outDir: 'dist'
+    outDir: 'dist',
   },
   resolve: {
     alias: {
@@ -18,9 +22,7 @@ export default defineConfig({
         global: 'globalThis',
       },
       plugins: [
-        NodeGlobalsPolyfillPlugin({
-          buffer: true,
-        }),
+        NodeGlobalsPolyfillPlugin({ process: true, buffer: true }),
       ],
     },
   },


### PR DESCRIPTION
## Summary
- add `MarkdownRenderer` component
- use it from `RepoBrowser`
- configure Vite polyfills
- update frontend dependencies
- streamline `dev.sh`
- document repo viewer Markdown handling

## Testing
- `npm run build` *(fails: vite not found)*