### PR TITLE
Fix RepoBrowser width and add horizontal scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@
 2025-05-24 Improve RepoBrowser rendering for markdown, json and code
 2025-05-24 Add Markdown styling and fix code spacing in RepoBrowser
 2025-05-24 Switch RepoBrowser to react-markdown with unified code highlighting
+2025-05-24 Make RepoBrowser width responsive with horizontal scroll

--- a/frontend/src/components/ProjectDetail.tsx
+++ b/frontend/src/components/ProjectDetail.tsx
@@ -37,7 +37,7 @@ export default function ProjectDetail({ project }: { project: Project }) {
         </div>
       </div>
     </article>
-    <div className="mt-4">
+    <div className="mt-4 w-full">
       <RepoBrowser repoUrl={project.repo_url} />
     </div>
     </>

--- a/frontend/src/components/RepoBrowser.tsx
+++ b/frontend/src/components/RepoBrowser.tsx
@@ -106,7 +106,7 @@ export default function RepoBrowser({ repoUrl }: { repoUrl: string }) {
   }
 
   return (
-    <div className="flex border rounded h-96 overflow-hidden text-sm">
+    <div className="flex border rounded h-96 overflow-hidden text-sm w-full max-w-full md:max-w-screen-lg">
       <div className="w-1/3 overflow-y-auto border-r p-2">
         {parentPath && (
           <div className="cursor-pointer" onClick={() => openDir(parentPath)}>
@@ -123,7 +123,7 @@ export default function RepoBrowser({ repoUrl }: { repoUrl: string }) {
           </div>
         ))}
       </div>
-      <div className="w-2/3 overflow-y-auto p-2">
+      <div className="w-2/3 overflow-y-auto overflow-x-auto p-2">
         {content ? (
           typeof content === 'string' ? (
             <div dangerouslySetInnerHTML={{ __html: content }} />

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -20,7 +20,7 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
   }
 
   return (
-    <div className="p-4 max-w-3xl mx-auto">
+    <div className="p-4 w-full max-w-screen-lg mx-auto">
       <ProjectDetail project={project} />
     </div>
   )


### PR DESCRIPTION
## Summary
- allow RepoBrowser to take full width and constrain to screen size
- add horizontal scrolling for long lines
- expand project detail page layout

## Testing
- `npm test` *(fails: Missing script)*
- `pytest`