### PR TITLE
Add exclude_paths option to projects and update detail view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,4 @@
 2025-05-24 Make RepoBrowser width responsive with horizontal scroll
 2025-05-25 Autoload README in RepoBrowser
 2025-05-25 Add modern style
+2025-05-21 Add exclude_paths field and remove GitHub link from project detail view

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Each JSON file must match this schema:
   "image": "images/my-image.png",
   "repo_url": "https://github.com/user/my-project",
   "description": "Project description",
-  "demo_url": "https://example.com/demo"
+  "demo_url": "https://example.com/demo",
+  "exclude_paths": ["dist", "node_modules"]
 }
 ```
+`exclude_paths` is optional and lists files that should be hidden in the built-in repository viewer.

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing import Optional
+from typing import Optional, List
 
 
 class Project(BaseModel):
@@ -9,3 +9,4 @@ class Project(BaseModel):
     repo_url: str
     description: str
     demo_url: str
+    exclude_paths: Optional[List[str]] = None

--- a/backend/project_store/another-project.json
+++ b/backend/project_store/another-project.json
@@ -4,5 +4,6 @@
   "image": "images/2.png",
   "repo_url": "https://github.com/example/another-project",
   "description": "This is another sample project to showcase multiple entries.",
-  "demo_url": "https://example.com/demo2"
+  "demo_url": "https://example.com/demo2",
+  "exclude_paths": ["dist", "node_modules"]
 }

--- a/backend/project_store/sample-project.json
+++ b/backend/project_store/sample-project.json
@@ -4,5 +4,6 @@
   "image": "images/1.png",
   "repo_url": "https://github.com/knavillus1/codex_bootstrap",
   "description": "This is a sample project used to demonstrate the portfolio layout.",
-  "demo_url": "https://example.com/demo"
+  "demo_url": "https://example.com/demo",
+  "exclude_paths": ["dist", "node_modules"]
 }

--- a/frontend/src/components/ProjectDetail.tsx
+++ b/frontend/src/components/ProjectDetail.tsx
@@ -26,14 +26,6 @@ export default function ProjectDetail({ project }: { project: Project }) {
           >
             Live Demo
           </a>
-          <a
-            className="text-primary hover:text-secondary underline"
-            href={project.repo_url}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            GitHub Repo
-          </a>
         </div>
       </div>
     </article>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5,4 +5,5 @@ export interface Project {
   repo_url: string
   description: string
   demo_url: string
+  exclude_paths?: string[]
 }


### PR DESCRIPTION
## Summary
- add `exclude_paths` to project definitions
- document new optional field in README
- remove external GitHub link from project detail page
- keep type definitions in sync with backend model

## Testing
- `pytest -q`
