### PR TITLE
Implement repo omissions filtering and UI highlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,5 @@
 2025-05-21 Add exclude_paths field and remove GitHub link from project detail view
 2025-05-21 Reorganize project store with projects directory and GlobalRepoOmissions
 2025-05-21 Create new repo in LightngFS for each new repo to avoid collisions
+2025-05-21 Use global omissions with per-project exclusions and highlight selected file in repo browser
+  npm build failed: vite not found

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ DEBUG=1 VITE_ENABLE_DEBUG=true ./dev.sh
 Project definition files live in `backend/project_store/projects`. Optional
 images can be placed in `backend/project_store/images` and referenced from the
 `image` field. Global repository exclusions can be listed in
-`backend/project_store/GlobalRepoOmissions.json` but are not yet used.
+`backend/project_store/GlobalRepoOmissions.json`.
+These global omissions are combined with each project's `exclude_paths` to hide
+files in the in-browser repository viewer.
 
 The JSON filename must match the `id` value exactly (e.g. `my-project.json`).
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 import logging
 import os
+import json
 
 from .models import Project
 from .repositories.project_repository import FileProjectRepository
@@ -28,6 +29,17 @@ repo = FileProjectRepository(
     Path(__file__).resolve().parents[1] / "project_store" / "projects"
 )
 
+global_omissions_path = (
+    Path(__file__).resolve().parents[1] / "project_store" / "GlobalRepoOmissions.json"
+)
+
+
+def load_global_omissions() -> list[str]:
+    if not global_omissions_path.exists():
+        return []
+    with global_omissions_path.open("r") as f:
+        return json.load(f)
+
 images_path = Path(__file__).resolve().parents[1] / "project_store" / "images"
 app.mount("/images", StaticFiles(directory=images_path), name="images")
 
@@ -48,6 +60,12 @@ def get_project(project_id: str):
         raise HTTPException(status_code=404, detail="Project not found")
     logger.debug("Found project %s", project_id)
     return project
+
+
+@app.get("/api/global_repo_omissions", response_model=list[str])
+def get_global_repo_omissions():
+    logger.debug("Returning global repo omissions")
+    return load_global_omissions()
 
 # Path to the built frontend assets
 build_path = Path(__file__).resolve().parents[1] / 'frontend' / 'dist'

--- a/frontend/src/components/ProjectDetail.tsx
+++ b/frontend/src/components/ProjectDetail.tsx
@@ -30,7 +30,7 @@ export default function ProjectDetail({ project }: { project: Project }) {
       </div>
     </article>
     <div className="mt-6 w-full">
-      <RepoBrowser repoUrl={project.repo_url} />
+      <RepoBrowser repoUrl={project.repo_url} excludePaths={project.exclude_paths} />
     </div>
     </>
   )


### PR DESCRIPTION
## Summary
- fetch global repo omissions via new API endpoint
- filter RepoBrowser entries using global and per-project omission lists
- highlight selected file in RepoBrowser
- expose omissions to RepoBrowser through ProjectDetail
- document omissions usage in README

## Testing
- `pytest -q`
- `npm run build` *(fails: vite not found)*