### PR TITLE
Fix README highlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@
 2025-05-21 Use global omissions with per-project exclusions and highlight selected file in repo browser
   npm build failed: vite not found
 2025-05-21 Make RepoBrowser height dynamic and shrink code font
+2025-05-26 Fix README selection highlight in RepoBrowser

--- a/frontend/src/components/RepoBrowser.tsx
+++ b/frontend/src/components/RepoBrowser.tsx
@@ -96,7 +96,8 @@ export default function RepoBrowser({
     const names = await pfs.readdir(dir + path)
     const ents: Entry[] = []
     for (const name of names) {
-      const fullPath = `${path}/${name}`
+      const normalized = path.endsWith('/') ? path.slice(0, -1) : path
+      const fullPath = `${normalized}/${name}`
       if (isExcluded(fullPath)) continue
       const stat = await pfs.stat(`${dir}${fullPath}`)
       ents.push({ name, path: fullPath, isDir: stat.isDirectory() })


### PR DESCRIPTION
## Summary
- ensure paths for root directory entries don't start with double slashes
- document the highlight fix in CHANGELOG

## Testing
- `pytest -q`