### PR TITLE
Fix repo browser not refreshing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,5 @@
   npm build failed: vite not found
 2025-05-21 Make RepoBrowser height dynamic and shrink code font
 2025-05-26 Fix README selection highlight in RepoBrowser
+2025-05-21 Force new LightningFS instance per load to avoid stale repos
+  npm build failed: vite not found

--- a/frontend/src/components/RepoBrowser.tsx
+++ b/frontend/src/components/RepoBrowser.tsx
@@ -42,8 +42,8 @@ export default function RepoBrowser({
 
   useEffect(() => {
     async function cloneRepo() {
-      // Use a unique FS name per repoUrl to avoid cached conflicts
-      const fsName = `repo-fs-${btoa(repoUrl)}`
+      // Use a unique FS name per load to ensure we start fresh each time
+      const fsName = `repo-fs-${btoa(repoUrl)}-${Date.now()}`
       const fs = new LightningFS(fsName)
       fsRef.current = fs
       const pfs = fs.promises


### PR DESCRIPTION
## Summary
- ensure RepoBrowser clones into a fresh LightningFS instance on each load
- document error

## Testing
- `pytest -q`
- `npm run build` *(fails: vite not found)*