### PR TITLE
Fix static mount and update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,4 @@
 2025-05-21 Force new LightningFS instance per load to avoid stale repos
   npm build failed: vite not found
 2025-05-27 Replace file-based project store with Azure Table Storage
+2025-05-23 Handle missing frontend build directory and document build output

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Reimagined Succotash is a modern portfolio and project showcase web application.
 ## Local Development
 Set `AZURE_TABLES_ACCOUNT_URL` and `AZURE_TABLES_TABLE_NAME` then run `./dev.sh` to start both backend and frontend for local development.
 
+For a production build, run `npm run build` inside the `frontend` directory. The compiled files are placed in `backend/app/static` and served by FastAPI.
+
 ## Technologies Used
 - Python 3, FastAPI, Uvicorn
 - React 18, Vite, Tailwind CSS

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -141,4 +141,9 @@ def get_global_repo_omissions():
 
 # Mount static frontend build output
 static_dir = Path(__file__).parent / "static"
-app.mount("/", StaticFiles(directory=static_dir, html=True), name="static")
+if static_dir.exists():
+    app.mount("/", StaticFiles(directory=static_dir, html=True), name="static")
+else:
+    logger.warning(
+        "Static directory %s not found. Skipping static file mounting.", static_dir
+    )


### PR DESCRIPTION
## Summary
- skip static file mount if directory does not exist
- document production build output directory
- note changes in CHANGELOG

## Testing
- `./run_tests.sh` *(fails: DefaultAzureCredential failed to retrieve a token)*