### PR TITLE
Allow customizing CORS origins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,5 @@
   npm build failed: vite not found
 2025-05-27 Replace file-based project store with Azure Table Storage
 2025-05-23 Handle missing frontend build directory and document build output
+2025-05-28 Accept allowed origins from environment variable
+  tests failed: missing Azure credentials

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Reimagined Succotash is a modern portfolio and project showcase web application.
 - Easy local development with a single startup script (`dev.sh`)
 
 ## Local Development
-Set `AZURE_TABLES_ACCOUNT_URL` and `AZURE_TABLES_TABLE_NAME` then run `./dev.sh` to start both backend and frontend for local development.
+Set `AZURE_TABLES_ACCOUNT_URL` and `AZURE_TABLES_TABLE_NAME` then run `./dev.sh` to start both backend and frontend for local development. Optionally set `ALLOW_ORIGINS` to a comma-separated list of origins for CORS; it defaults to `http://localhost:5173`.
 
 For a production build, run `npm run build` inside the `frontend` directory. The compiled files are placed in `backend/app/static` and served by FastAPI.
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,9 +23,14 @@ logger = logging.getLogger(__name__)
 
 app = FastAPI()
 
+# Configure allowed CORS origins from environment variable. Defaults to
+# "http://localhost:5173" for local development.
+allowed_origins_env = os.getenv("ALLOW_ORIGINS", "http://localhost:5173")
+allowed_origins = [o.strip() for o in allowed_origins_env.split(",") if o.strip()]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173"],
+    allow_origins=allowed_origins,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/dev.sh
+++ b/dev.sh
@@ -16,6 +16,10 @@ export DEBUG VITE_ENABLE_DEBUG
 
 export AZURE_TABLES_ACCOUNT_URL AZURE_TABLES_TABLE_NAME AZURE_BLOB_STORAGE_ACCOUNT_URL AZURE_BLOB_CONTAINER_NAME
 
+# CORS allowed origins for the backend (comma-separated)
+: "${ALLOW_ORIGINS:=http://localhost:5173}"
+export ALLOW_ORIGINS
+
 # Function to kill existing processes
 kill_existing_processes() {
   echo "Checking for existing backend and frontend processes..."


### PR DESCRIPTION
## Summary
- make backend CORS allowed origins configurable with `ALLOW_ORIGINS`
- set default for `ALLOW_ORIGINS` in `dev.sh`
- document new variable in README
- note test failures due to missing Azure credentials

## Testing
- `./run_tests.sh` *(fails: DefaultAzureCredential failed)*